### PR TITLE
renamed result in bucket call in order to use api res

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -56,7 +56,7 @@ module.exports = function(app) {
             //couchbase call here
             console.log(id);
 
-            bucket.remove(id, res, function(err, res) {
+            bucket.remove(id, function(err, results) {
                 if (err) {
                     console.log('operation failed', err);
                     /*
@@ -64,7 +64,7 @@ module.exports = function(app) {
                      */
                     return;
                 }
+                res.send('success! job ' + id + ' was deleted');
             });
-            res.send('success! job ' + id + ' was deleted');
         });
     };


### PR DESCRIPTION
bug fix. Renaming bucket variable in order to use parent `res` variable. This allows us to return a response to the client
